### PR TITLE
Fix ei nov24 rel

### DIFF
--- a/ecoinvent_migrate/main.py
+++ b/ecoinvent_migrate/main.py
@@ -279,8 +279,8 @@ Please check the outputs carefully before applying them."""
         name=f"{source_db_name}-{target_db_name}",
         description=description,
         contributors=[
-            {"title": "ecoinvent association", "path": "https://ecoinvent.org/", "role": "author"},
-            {"title": "Chris Mutel", "path": "https://chris.mutel.org/", "role": "wrangler"},
+            {"title": "ecoinvent association", "path": "https://ecoinvent.org/", "roles": ["author"]},
+            {"title": "Chris Mutel", "path": "https://chris.mutel.org/", "roles": ["wrangler"]},
         ],
         mapping_source=MappingConstants.ECOSPOLD2_BIO,
         mapping_target=MappingConstants.ECOSPOLD2_BIO,

--- a/ecoinvent_migrate/main.py
+++ b/ecoinvent_migrate/main.py
@@ -168,8 +168,8 @@ def generate_technosphere_mapping(
         name=f"{source_db_name}-{target_db_name}",
         description=description,
         contributors=[
-            {"title": "ecoinvent association", "path": "https://ecoinvent.org/", "roles": ["author"]},
-            {"title": "Chris Mutel", "path": "https://chris.mutel.org/", "roles": ["wrangler"]},
+            {"title": "ecoinvent association", "path": "https://ecoinvent.org/", "role": "author"},
+            {"title": "Chris Mutel", "path": "https://chris.mutel.org/", "role": "wrangler"},
         ],
         mapping_source=MappingConstants.ECOSPOLD2,
         mapping_target=MappingConstants.ECOSPOLD2,
@@ -319,9 +319,9 @@ Please check the outputs carefully before applying them."""
             {
                 "title": "ecoinvent association",
                 "path": "https://ecoinvent.org/",
-                "roles": ["author"],
+                "role": "author",
             },
-            {"title": "Chris Mutel", "path": "https://chris.mutel.org/", "roles": ["wrangler"]},
+            {"title": "Chris Mutel", "path": "https://chris.mutel.org/", "role": "wrangler"},
         ],
         mapping_source=MappingConstants.ECOSPOLD2_BIO,
         mapping_target=MappingConstants.ECOSPOLD2_BIO,

--- a/test.py
+++ b/test.py
@@ -1,0 +1,6 @@
+import ecoinvent_migrate as em
+
+em.generate_biosphere_mapping(
+    '3.10', '3.10.1'
+)
+

--- a/test.py
+++ b/test.py
@@ -1,6 +1,0 @@
-import ecoinvent_migrate as em
-
-em.generate_biosphere_mapping(
-    '3.10', '3.10.1'
-)
-


### PR DESCRIPTION
This PR depends on #4 

Fix handling of biosphere changes in newer ecoinvent releases

This PR addresses issues with processing biosphere changes in newer ecoinvent releases (3.10.1+) where:
1. in 3.11 EE Deletions sheet structure has changed to a new format with deletion/replacement exchanges.  (they added some weird multi-column thing)
2. in 3.10.1 EE deletions was empty which cause an error in 'source_target_biosphere_pair()'  when trying to 'data[0]'
3. Empty datasets were causing errors when adding to Datapackage due to change in randonneur.

Changes:
- Added handling for new column format in EE Deletions sheet
- Added data validation before Datapackage creation
- Improved handling of empty datasets 
- Added better logging for format detection
- Added early return for cases with no changes

Testing:
- Works with older formats (pre 3.10)
- Works with newer formats (3.10.1+)
- Handles empty sheets correctly
- Maintains same output structure for compatibility

Technical notes:
- No changes to output data structure/format 
- Maintains backward compatibility with older versions

Side note also fixed the same error in #4  but for technosphere changes (I forgot about that earlier)