### PR TITLE
Refactor relabel function

### DIFF
--- a/src/ecoinvent_migrate/wrangling.py
+++ b/src/ecoinvent_migrate/wrangling.py
@@ -52,11 +52,33 @@ def split_by_semicolon(row: dict, version: str) -> list[dict]:
 
 
 def relabel(obj: dict) -> dict:
-    """Change from ecospold2-ish labels to Randonneur constants.ECOSPOLD2 labels"""
+    """Change from ecospold2-ish labels to Randonneur constants.ECOSPOLD2 labels.
+
+    Logs a warning if the target key already exists and the source key is missing.
+    """
     obj = copy(obj)
-    obj["name"] = obj.pop("activity_name")
-    obj["reference product"] = obj.pop("product_name")
-    obj["location"] = obj.pop("geography")
+    mappings = {
+        "activity_name": "name",
+        "product_name": "reference product",
+        "geography": "location",
+    }
+
+    for old_key, new_key in mappings.items():
+        if old_key in obj:
+            # If the old key exists, rename it to the new key.
+            # This will overwrite the new key if it somehow already exists.
+            obj[new_key] = obj.pop(old_key)
+        elif new_key in obj:
+            # If the old key doesn't exist, but the new key does,
+            # log a warning and assume it's already (partially) relabeled.
+            # No change needed as the desired key is already present.
+            logger.warning(
+                f"Key '{new_key}' already exists and '{old_key}' not found in object. "
+                "Assuming already relabeled: {data}", data=obj
+            )
+        # Optional: else: neither key exists, potentially log this too if needed.
+        # logger.debug(f"Neither '{old_key}' nor '{new_key}' found in object: {data}", data=obj)
+
     return obj
 
 


### PR DESCRIPTION
Currently, migration from 3.9.1 to 3.10 seems broken (`filepath = generate_technosphere_mapping("3.9.1", "3.10")`)

```python
KeyError                                  Traceback (most recent call last)
Cell In[2], line 1
----> 1 filepath = generate_technosphere_mapping("3.9.1", "3.10")

File ~/Projects/Personal/ecoinvent_migrate/src/ecoinvent_migrate/main.py:128, in generate_technosphere_mapping(source_version, target_version, project_name, system_model, ecoinvent_username, ecoinvent_password, write_logs, write_file, licenses, output_directory, output_version, description)
    122 for item in changed_sources:
    123     logger.warning(
    124         "Source dataset changed but neither change report nor patches have migrations: {s}",
    125         s=source_lookup[item],
    126     )
--> 128 data = [{"source": relabel(obj["source"]), "target": relabel(obj["target"])} for obj in data]
    129 data = split_replace_disaggregate(data=data, target_lookup=target_lookup)
    131 if not data["replace"] and not data["disaggregate"]:

File ~/Projects/Personal/ecoinvent_migrate/src/ecoinvent_migrate/main.py:128, in <listcomp>(.0)
    122 for item in changed_sources:
    123     logger.warning(
    124         "Source dataset changed but neither change report nor patches have migrations: {s}",
    125         s=source_lookup[item],
    126     )
--> 128 data = [{"source": relabel(obj["source"]), "target": relabel(obj["target"])} for obj in data]
    129 data = split_replace_disaggregate(data=data, target_lookup=target_lookup)
    131 if not data["replace"] and not data["disaggregate"]:

File ~/Projects/Personal/ecoinvent_migrate/src/ecoinvent_migrate/wrangling.py:58, in relabel(obj)
     56 obj = copy(obj)
     57 print(obj)
---> 58 obj["name"] = obj.pop("activity_name")
     59 obj["reference product"] = obj.pop("product_name")
     60 obj["location"] = obj.pop("geography")

KeyError: 'activity_name'

```

This PR addresses a `KeyError: 'activity_name'` occurring in the `relabel` function during migration generation (3.9.1 to 3.10).

The fix adds checks within `relabel` to handle cases where input dictionaries might already contain the target keys (like `"name"`) instead of the source keys (like `"activity_name"`). This prevents the `KeyError` by logging a warning and skipping the rename if the target key already exists.

While this resolves the immediate error, further investigation might be needed to understand why the input data to `relabel` is sometimes already partially transformed.

FYI this is only happening between these two versions. And its multiple datasets.

```python
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': "modified Solvay process, Hou's process", 'location': 'GLO', 'reference product': 'ammonium chloride', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': "modified Solvay process, Hou's process", 'location': 'GLO', 'reference product': 'ammonium chloride', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': "modified Solvay process, Hou's process", 'location': 'GLO', 'reference product': 'ammonium chloride', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': "soda ash production, dense, Hou's process", 'location': 'GLO', 'reference product': 'ammonium chloride', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': "soda ash production, dense, Hou's process", 'location': 'GLO', 'reference product': 'ammonium chloride', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': "soda ash production, dense, Hou's process", 'location': 'GLO', 'reference product': 'ammonium chloride', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'Mannheim process', 'location': 'RER', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'Mannheim process', 'location': 'RER', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'Mannheim process', 'location': 'RER', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'hydrochloric acid production, Mannheim process', 'location': 'RER', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'hydrochloric acid production, Mannheim process', 'location': 'RER', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'hydrochloric acid production, Mannheim process', 'location': 'RER', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.353 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'Mannheim process', 'location': 'RoW', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'Mannheim process', 'location': 'RoW', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'Mannheim process', 'location': 'RoW', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'hydrochloric acid production, Mannheim process', 'location': 'RoW', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'hydrochloric acid production, Mannheim process', 'location': 'RoW', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'hydrochloric acid production, Mannheim process', 'location': 'RoW', 'reference product': 'sodium sulfate, anhydrite', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'wheat production, Swiss integrated production, intensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'wheat production, Swiss integrated production, intensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'wheat production, Swiss integrated production, intensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'wheat grain production, Swiss integrated production, intensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'wheat grain production, Swiss integrated production, intensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'wheat grain production, Swiss integrated production, intensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'wheat production, Swiss integrated production, extensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'wheat production, Swiss integrated production, extensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'wheat production, Swiss integrated production, extensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'wheat grain production, Swiss integrated production, extensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'wheat grain production, Swiss integrated production, extensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'wheat grain production, Swiss integrated production, extensive', 'location': 'CH', 'reference product': 'straw', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'nitrogen, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'nitrogen, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'nitrogen, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'nitrogen, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'nitrogen, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'nitrogen, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'nitrogen, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'nitrogen, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'nitrogen, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'nitrogen, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'nitrogen, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'nitrogen, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'argon, crude, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'argon, crude, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'argon, crude, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'argon, crude, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.354 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'argon, crude, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.355 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'argon, crude, liquid', 'location': 'RER', 'unit': 'kg'}
2025-05-04 20:27:17.355 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'argon, crude, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.355 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'argon, crude, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.355 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'air separation, cryogenic', 'reference product': 'argon, crude, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.355 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'name' already exists and 'activity_name' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'argon, crude, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.355 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'reference product' already exists and 'product_name' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'argon, crude, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.355 | WARNING  | ecoinvent_migrate.wrangling:relabel:75 - Key 'location' already exists and 'geography' not found in object. Assuming already relabeled: {'name': 'industrial gases production, cryogenic air separation', 'reference product': 'argon, crude, liquid', 'location': 'RoW', 'unit': 'kg'}
2025-05-04 20:27:17.445 | INFO     | ecoinvent_migrate.main:generate_technosphere_mapping:168 - Writing output file /home/marsh/.local/share/ecoinvent_migrate/ecoinvent-3.9.1-cutoff-ecoinvent-3.10-cutoff.json
```