### PR TITLE
Ensure comments are safely stripped in source_target_biosphere_pair

### DIFF
--- a/src/ecoinvent_migrate/wrangling.py
+++ b/src/ecoinvent_migrate/wrangling.py
@@ -413,19 +413,23 @@ def source_target_biosphere_pair(
         has_target = not any(isnan(row.get(v, float("nan"))) for v in target_labels.values())
 
         if has_target:
+            comment_val = row.get("Comment")
             formatted["replace"].append(
                 {
                     "source": source_entry,
                     "target": {k: row[v].strip() for k, v in target_labels.items()},
                     "conversion_factor": float(row.get("Conversion Factor (old-new)", 1.0)),
-                    "comment": row.get("Comment").strip(),
+                    # Check if comment is a string before stripping, otherwise use empty string
+                    "comment": comment_val.strip() if isinstance(comment_val, str) else "",
                 }
             )
         elif keep_deletions:
+            comment_val = row.get("Comment")
             formatted["delete"].append(
                 {
                     "source": source_entry,
-                    "comment": row.get("Comment").strip(),
+                    # Check if comment is a string before stripping, otherwise use empty string
+                    "comment": comment_val.strip() if isinstance(comment_val, str) else "",
                 }
             )
 

--- a/src/ecoinvent_migrate/wrangling.py
+++ b/src/ecoinvent_migrate/wrangling.py
@@ -428,7 +428,6 @@ def source_target_biosphere_pair(
             formatted["delete"].append(
                 {
                     "source": source_entry,
-                    # Check if comment is a string before stripping, otherwise use empty string
                     "comment": comment_val.strip() if isinstance(comment_val, str) else "",
                 }
             )

--- a/src/ecoinvent_migrate/wrangling.py
+++ b/src/ecoinvent_migrate/wrangling.py
@@ -419,7 +419,6 @@ def source_target_biosphere_pair(
                     "source": source_entry,
                     "target": {k: row[v].strip() for k, v in target_labels.items()},
                     "conversion_factor": float(row.get("Conversion Factor (old-new)", 1.0)),
-                    # Check if comment is a string before stripping, otherwise use empty string
                     "comment": comment_val.strip() if isinstance(comment_val, str) else "",
                 }
             )


### PR DESCRIPTION
In the change report for 3.10, most of the values for "comment" in EE Deletions sheet are null, which results in the error below.

```python
In [2]: filepath = generate_biosphere_mapping('3.9.1','3.10')
2025-05-04 21:32:27.411 | INFO     | ecoinvent_migrate.utils:configure_logs:18 - Writing logs to /home/marsh/.local/state/ecoinvent_migrate/log/2025-05-04T21-32-27
2025-05-04 21:32:28.454 | INFO     | ecoinvent_migrate.data_io:get_change_report:105 - Versions available for this license: ['3.11', '3.10.1', '3.10', '3.9.1', '3.9', '3.8', '3.7.1', '3.7', '3.6', '3.5', '3.4', '3.3', '3.2', '3.1', '3.01', '2']
2025-05-04 21:32:29.102 | INFO     | ecoinvent_migrate.data_io:get_change_report:118 - Using change report annex file Change Report Annex v3.9.1 - v3.10.xlsx
2025-05-04 21:32:29.103 | INFO     | ecoinvent_migrate.main:generate_biosphere_mapping:206 - The `EE Deletions` format is not consistent across versions.
Please check the outputs carefully before applying them.
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[2], line 1
----> 1 filepath = generate_biosphere_mapping('3.9.1','3.10')

File ~/Projects/Personal/Activity_migrator/.venv/lib/python3.11/site-packages/ecoinvent_migrate/main.py:256, in generate_biosphere_mapping(source_version, target_version, keep_deletions, project_name, ecoinvent_username, ecoinvent_password, write_logs, write_file, licenses, output_directory, output_version, description)
    254 else:
    255     data = df.to_dict(orient="records")
--> 256     data = source_target_biosphere_pair(
    257         data=data,
    258         source_version=source_version,
    259         target_version=target_version,
    260         keep_deletions=keep_deletions,
    261     )
    262     # Ensure both keys exist
    263     if "delete" not in data:

File ~/Projects/Personal/Activity_migrator/.venv/lib/python3.11/site-packages/ecoinvent_migrate/wrangling.py:421, in source_target_biosphere_pair(data, source_version, target_version, keep_deletions)
    413 has_target = not any(isnan(row.get(v, float("nan"))) for v in target_labels.values())
    415 if has_target:
    416     formatted["replace"].append(
    417         {
    418             "source": source_entry,
    419             "target": {k: row[v].strip() for k, v in target_labels.items()},
    420             "conversion_factor": float(row.get("Conversion Factor (old-new)", 1.0)),
--> 421             "comment": row.get("Comment").strip(),
    422         }
    423     )
    424 elif keep_deletions:
    425     formatted["delete"].append(
    426         {
    427             "source": source_entry,
    428             "comment": row.get("Comment").strip(),
    429         }
    430     )

AttributeError: 'float' object has no attribute 'strip'
```

This PR fixes the AttributeError by ensuring the 'Comment' field is treated as a string before stripping, handling cases where it might be null.